### PR TITLE
fix: Move react-native-dotenv to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "firebase": "11.6.1",
         "react": "18.3.1",
         "react-native": "0.76.9",
+        "react-native-dotenv": "^3.4.11",
         "react-native-modal-datetime-picker": "^14.0.0",
         "react-native-safe-area-context": "4.8.1",
         "react-native-screens": "~3.30.0",
@@ -43,7 +44,6 @@
         "jest": "^29.7.0",
         "jest-expo": "^53.0.0",
         "metro-react-native-babel-preset": "^0.77.0",
-        "react-native-dotenv": "^3.4.11",
         "react-test-renderer": "^18.3.1",
         "ts-jest": "^29.3.2",
         "typescript": "^5.3.3"
@@ -12211,7 +12211,6 @@
       "version": "3.4.11",
       "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-3.4.11.tgz",
       "integrity": "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-native-safe-area-context": "4.8.1",
     "react-native-screens": "~3.30.0",
     "react-native-svg": "13.4.0",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "react-native-dotenv": "^3.4.11"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -45,7 +46,7 @@
     "jest": "^29.7.0",
     "jest-expo": "^53.0.0",
     "metro-react-native-babel-preset": "^0.77.0",
-    "react-native-dotenv": "^3.4.11",
+
     "react-test-renderer": "^18.3.1",
     "ts-jest": "^29.3.2",
     "typescript": "^5.3.3"


### PR DESCRIPTION
Moved react-native-dotenv from devDependencies to dependencies to resolve persistent Hermes runtime error "Property 'require' doesn't exist".