### PR TITLE
fix: Add OPENAI_API_KEY declaration to env.d.ts

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -8,4 +8,7 @@ declare module '@env' {
   export const EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: string;
   export const EXPO_PUBLIC_FIREBASE_APP_ID: string;
 
+  // Add the missing declaration for OPENAI_API_KEY
+  export const OPENAI_API_KEY: string;
+
 }


### PR DESCRIPTION
Added missing OPENAI_API_KEY declaration to env.d.ts to resolve TypeScript errors and potentially fix the persistent Hermes runtime error "Property 'require' doesn't exist".